### PR TITLE
Update mod_loader for Darktide patch 1.0.40

### DIFF
--- a/binaries/mod_loader
+++ b/binaries/mod_loader
@@ -324,7 +324,7 @@ local StateLoadAudioSettings = require("scripts/game_states/boot/state_load_audi
 local StateLoadBootAssets = require("scripts/game_states/boot/state_load_boot_assets")
 
 -- Unused right now, but might be useful in case we want to re-add the state at some point
-local StateLoadMods = require("scripts/game_states/boot/state_load_mods")
+--local StateLoadMods = require("scripts/game_states/boot/state_load_mods")
 
 local StateLoadRenderSettings = require("scripts/game_states/boot/state_load_render_settings")
 local StateRequireScripts = require("scripts/game_states/boot/state_require_scripts")


### PR DESCRIPTION
Fix crash during launch when trying to load removed file `scripts/game_states/boot/state_load_mods`