### PR TITLE
Add Linux patcher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,20 @@
 
 ### This mod does not need to be added to your mod_load_order.txt file.
 
-## Installation:
+## Installation (Windows):
     1. Copy the Darktide Mod Loader files to your game directory and overwrite existing.
     2. Run the "toggle_darktide_mods.bat" script in your game folder.
     3. Copy the Darktide Mod Framework files to your "mods" directory (<game folder>/mods) and overwrite existing.
     3. Install other mods by downloading them from the Nexus site (https://www.nexusmods.com/warhammer40kdarktide) then adding them to "<game folder>/mods/mod_load_order.txt" with a text editor.
     
+## Installation (Linux):
+    1. All Windows instructions for installing/updating/removing apply to Linux, except:
+        - you need to use "toggle_darktide_mods.sh" instead of "toggle_darktide_mods.bat"
+        - you will need one of the following installed and on your path, please see the documentation for your distribution's package manager:
+            - `wine`
+            - `cargo` and `git`
+    If for some reason you experience problems using the wine patcher, you can force the use of a native patcher with `toggle_darktide_mods.sh -f`
+
 ## Disable mods:
     * Disable individual mods by removing their name from your mods/mod_load_order.txt file.
     * Run the "toggle_darktide_mods.bat" script at your game folder and choose to unpatch the bundle database to disable all mod loading.

--- a/toggle_darktide_mods.sh
+++ b/toggle_darktide_mods.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+set -e
+
+PATCHER_START="Starting Darktide patcher..."
+PATCHER_FAIL="Error patching the Darktide bundle database. See logs."
+
+CLEANUP_PATCHER=0
+
+FORCE_NATIVE=1
+[ "$1" = "-f" ] || [ "$1" = "--force" ] || FORCE_NATIVE=0
+
+HAS_WINE=1
+command -v wine >/dev/null 2>&1 || HAS_WINE=0
+
+
+build_native_patcher() {
+    if [ -e ./tools/dtkit-patch ]
+    then
+        read -p "Are you trying to update or remove the mod loader (y/n)? " RESPONSE
+        case "$RESPONSE" in
+            y|Y ) CLEANUP_PATCHER=1;;
+        esac
+        return 0
+    fi
+
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo >&2 "cargo not found, please install the cargo package, e.g. \"sudo apt install cargo\""
+        exit 1
+    fi
+    if ! command -v git >/dev/null 2>&1; then
+        echo >&2 "git not found, please install the git package, e.g. \"sudo apt install git\""
+        exit 1
+    fi
+    echo "Building database patcher"
+    rm -rf __dtkit 2>&1 || true
+    mkdir __dtkit
+    cd __dtkit
+    git clone https://github.com/ManShanko/dtkit-patch.git .
+    cargo build
+    cp ./target/debug/dtkit-patch ../tools/
+    cd ..
+    rm -rf __dtkit
+    echo "Database patcher built"
+}
+
+
+if [ "$FORCE_NATIVE" != 1 ] && [ "$HAS_WINE" = 1 ]
+then
+    echo $PATCHER_START
+    wine ./tools/__dtkit-patch.exe --toggle ./bundle || echo >&2 $PATCHER_FAIL
+    exit 0
+fi
+
+if [ "$FORCE_NATIVE" = 1 ]; then
+    echo "Using native patcher due to user override"
+else
+    echo "Wine not found in path, falling back to native patcher"
+fi
+
+build_native_patcher
+
+echo $PATCHER_START
+./tools/dtkit-patch --toggle ./bundle || echo >&2 $PATCHER_FAIL
+
+if [ "$CLEANUP_PATCHER" = 1 ] && [ -e ./tools/dtkit-patch ]
+then
+    rm ./tools/dtkit-patch
+fi
+


### PR DESCRIPTION
I've put together a basic patching script to save Linux users like me a little time/research.  I figured the best option for portability was to compile dtkit-patch locally rather than have you include and test another binary in your releases, which adds dependencies on `cargo` and `git`, but that shouldn't be a significant hurdle for any Linux user.

If you have any changes, please let me know.  I didn't find a public repo for the docs at https://dmf-docs.darkti.de/index#/installing-mods but would be happy to submit a PR for that as well if it exists.