### PR TITLE
Crashify mod name property that better matches inhouse tooling

### DIFF
--- a/mods/base/mod_manager.lua
+++ b/mods/base/mod_manager.lua
@@ -254,7 +254,8 @@ ModManager._load_mod = function (self, index)
 	mod.name = mod.name or mod_data.NAME or "Mod " .. mod.id
 	mod.state = "loading"
 
-	Crashify.print_property(string.format("Mod:%s:%s", id, mod.name), true)
+	Crashify.print_property(string.format("Mod:%s", mod.name), true)
+	print(string.format("[ModManager] Loading mod %s with id %s", mod.name, id))
 
 	self._mod_load_index = index
 


### PR DESCRIPTION
The current format of the mod logging messes with internal crash reporting tooling at Fatshark, the load order may still be important, so I'm removing that part and making it a seperate print.