### PR TITLE
Update mod_loader for Darktide v1.3.11 / v1.12.0 compatibility

### DIFF
--- a/binaries/mod_loader
+++ b/binaries/mod_loader
@@ -228,167 +228,128 @@ Mods.file.exists = file_exists
 -- Load remaining base modules
 exec("base/function", "require")
 
+-- DML v1.3.11 compatibility: StateRequireScripts is no longer a class in v1.3.11.
+-- The mod framework hooks must be deferred until StateGame/StateSplash classes exist.
+_mod_framework_ModManager = nil
+_mod_framework_initialized = false
+
 local init_mod_framework = function()
 
   print("[DMF]: Initializing basic mod hook system...")
   exec("base/function", "hook")
 
   -- The mod manager isn't in the bundles, so load our version from the mods folder
-  local ModManager = exec_with_return("base", "mod_manager")
+  _mod_framework_ModManager = exec_with_return("base", "mod_manager")
 
-  -- Initialize mods after loading managers and state_game files
-  Mods.hook.set("Base", "_G.CLASS.StateRequireScripts._require_scripts", function (req_func, ...)
-    local req_result = req_func(...)
+  print("[DMF]: Mod framework loaded, deferred initialization pending...")
+end
 
-    Managers.mod = Managers.mod or ModManager:new()
+-- Called from Main.update() once boot states have run and classes exist
+local _finish_mod_framework_init = function()
+  if _mod_framework_initialized then return end
+  if type(rawget(_G, "Managers")) ~= "table" then return end
+  -- Use rawget to bypass _G.CLASS.__index trap (returns string key if class not registered)
+  local state_game = _G.CLASS and rawget(_G.CLASS, "StateGame")
+  if type(state_game) ~= "table" then return end
 
-    -- Update mod manager
-    Mods.hook.set("Base", "_G.CLASS.StateGame.update", function (func, self, dt, ...)
-      Managers.mod:update(dt)
+  Managers.mod = Managers.mod or _mod_framework_ModManager:new()
 
-      return func(self, dt, ...)
-    end)
+  local all_ok = true
 
-    -- Skip splash view
-    Mods.hook.set("Base", "_G.CLASS.StateSplash.on_enter", function (func, self, ...)
-      local result = func(self, ...)
-
-      self._should_skip = true
-      self._continue = true
-
-      return result
-    end)
-
-    -- Trigger state change events
-    Mods.hook.set("Base", "_G.CLASS.GameStateMachine._change_state", function (func, self, ...)
-      local old_state = self._state
-      local old_state_name = old_state and self:current_state_name()
-
-      if old_state_name then
-        Managers.mod:on_game_state_changed("exit", old_state_name, old_state)
-      end
-
-      local result = func(self, ...)
-
-      local new_state = self._state
-      local new_state_name = new_state and self:current_state_name()
-
-      if new_state_name then
-        Managers.mod:on_game_state_changed("enter", new_state_name, new_state)
-      end
-
-      return result
-    end)
-
-    -- Trigger ending state change event
-    Mods.hook.set("Base", "_G.CLASS.GameStateMachine.destroy", function (func, self, ...)
-      local old_state = self._state
-      local old_state_name = old_state and self:current_state_name()
-
-      if old_state_name then
-        Managers.mod:on_game_state_changed("exit", old_state_name)
-      end
-
-      return func(self, ...)
-    end)
-
-    return req_result
+  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.StateGame.update", function (func, self, dt, ...)
+    Managers.mod:update(dt)
+    return func(self, dt, ...)
   end)
 
-  -- Set crashify modded property
-  Mods.hook.set("Base", "_G.CLASS.StateRequireScripts._get_is_modded", function ()
-    return true
+  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.StateSplash.on_enter", function (func, self, ...)
+    local result = func(self, ...)
+    self._should_skip = true
+    self._continue = true
+    return result
   end)
+
+  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.GameStateMachine._change_state", function (func, self, ...)
+    local old_state = self._state
+    local old_state_name = old_state and self:current_state_name()
+    if old_state_name then
+      Managers.mod:on_game_state_changed("exit", old_state_name, old_state)
+    end
+    local result = func(self, ...)
+    local new_state = self._state
+    local new_state_name = new_state and self:current_state_name()
+    if new_state_name then
+      Managers.mod:on_game_state_changed("enter", new_state_name, new_state)
+    end
+    return result
+  end)
+
+  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.GameStateMachine.destroy", function (func, self, ...)
+    local old_state = self._state
+    local old_state_name = old_state and self:current_state_name()
+    if old_state_name then
+      Managers.mod:on_game_state_changed("exit", old_state_name)
+    end
+    return func(self, ...)
+  end)
+
+  if all_ok then
+    _mod_framework_initialized = true
+    print("[DMF]: Mod framework fully initialized for v1.3.11!")
+  end
 end
 
 -- Original main script
 -- chunkname: @scripts/main.lua
+-- Updated for Darktide v1.3.11 (boot_state_paths architecture)
 
 Main = Main or {}
 
 require("scripts/boot_init")
-require("scripts/foundation/utilities/log")
+require("scripts/foundation/strict_environment")
+require("scripts/foundation/utilities/error")
 require("scripts/foundation/utilities/class")
 
 -- Expose classes at the global table
 exec("base/function", "class")
 
-require("scripts/foundation/utilities/patches")
+require("scripts/foundation/utilities/log")
 require("scripts/foundation/utilities/settings")
 require("scripts/foundation/utilities/table")
 
-local GameStateDebug = require("scripts/utilities/game_state_debug")
-local GameStateMachine = require("scripts/foundation/utilities/game_state_machine")
-local LocalizationManager = require("scripts/managers/localization/localization_manager")
-local PackageManager = require("scripts/foundation/managers/package/package_manager")
-local PackageManagerEditor = require("scripts/foundation/managers/package/package_manager_editor")
-local ParameterResolver = require("scripts/foundation/utilities/parameters/parameter_resolver")
-local StateBoot = require("scripts/game_states/state_boot")
-local StateLoadAudioSettings = require("scripts/game_states/boot/state_load_audio_settings")
-local StateLoadBootAssets = require("scripts/game_states/boot/state_load_boot_assets")
-local StateLoadRenderSettings = require("scripts/game_states/boot/state_load_render_settings")
-local StateRequireScripts = require("scripts/game_states/boot/state_require_scripts")
-local XboxLiveUtils = require("scripts/foundation/utilities/xbox_live_utils")
-local GAME_RESUME_COUNT = 0
+GAME_RESUME_COUNT = GAME_RESUME_COUNT or 0
+FRAME_INDEX = FRAME_INDEX or -1
 
 Main.init = function (self)
   Script.configure_garbage_collection(Script.ACCEPTABLE_GARBAGE, 0.1, Script.MAXIMUM_GARBAGE, 0.5, Script.FORCE_FULL_COLLECT_GARBAGE_LEVEL, 1, Script.MINIMUM_COLLECT_TIME_MS, 0.5, Script.MAXIMUM_COLLECT_TIME_MS, 1)
-  ParameterResolver.resolve_command_line()
-  ParameterResolver.resolve_game_parameters()
-  ParameterResolver.resolve_dev_parameters()
-  Log.load_config_from_parameters(GameParameters, DevParameters)
 
-  local fps = DEDICATED_SERVER and GameParameters.tick_rate or 30
+  local GameStateDebug = require("scripts/utilities/game_state_debug")
+  local GameStateMachine = require("scripts/foundation/utilities/game_state_machine")
+  local StateBoot = require("scripts/game_states/state_boot")
 
-  Application.set_time_step_policy("throttle", fps)
-
-  if IS_WINDOWS and type(GameParameters.window_title) == "string" and GameParameters.window_title ~= "" then
-    Window.set_title(GameParameters.window_title)
-  end
-
-  local package_manager = LEVEL_EDITOR_TEST and PackageManagerEditor:new() or PackageManager:new()
-  local localization_manager = LocalizationManager:new()
-  local params = {
-    index_offset = 1,
-    next_state = "StateGame",
-    states = {
-      {
-        StateLoadBootAssets,
-        {
-          package_manager = package_manager,
-          localization_manager = localization_manager,
-        },
-      },
-      {
-        StateRequireScripts,
-        {
-          package_manager = package_manager,
-        },
-      },
-      {
-        StateLoadAudioSettings,
-        {},
-      },
+  local start_params = {
+    next_state_class_name = "StateGame",
+    boot_state_paths = {
+      "scripts/game_states/boot/boot_state_set_globals",
+      "scripts/game_states/boot/boot_state_apply_patches",
+      "scripts/game_states/boot/boot_state_resolve_parameters",
+      "scripts/game_states/boot/boot_state_create_boot_ui",
+      "scripts/game_states/boot/boot_state_load_render_settings",
+      "scripts/game_states/boot/boot_state_init_managers",
+      "scripts/game_states/boot/boot_state_load_boot_assets",
+      "scripts/game_states/boot/boot_state_require_foundation_scripts",
+      "scripts/game_states/boot/boot_state_init_crashify",
+      "scripts/game_states/boot/boot_state_init_testify",
+      "scripts/game_states/boot/boot_state_require_game_scripts",
+      "scripts/game_states/boot/boot_state_load_audio_settings",
+      "scripts/game_states/boot/boot_state_activate_plugins",
+      "scripts/game_states/boot/boot_state_startup_tests",
+      "scripts/game_states/boot/boot_state_last",
     },
-    package_manager = package_manager,
-    localization_manager = localization_manager,
   }
-
-  if PLATFORM == "win32" and not LEVEL_EDITOR_TEST then
-    table.insert(params.states, 1, {
-      StateLoadRenderSettings,
-      {},
-    })
-  end
-
-  if LEVEL_EDITOR_TEST then
-    Wwise.load_bank("wwise/world_sound_fx")
-  end
 
   rawset(_G, "GameStateDebugInfo", GameStateDebug:new())
 
-  self._package_manager = package_manager
-  self._sm = GameStateMachine:new(nil, StateBoot, params, nil, nil, "", "Main", true)
+  self._sm = GameStateMachine:new(nil, StateBoot, start_params, nil, nil, "", "Main", true)
 
   -- #######################
   -- ## Mod intialization ##
@@ -397,7 +358,21 @@ Main.init = function (self)
 end
 
 Main.update = function (self, dt)
+  FRAME_INDEX = FRAME_INDEX + 1
+
+  -- DML v1.3.11: finish mod framework init once classes are available
+  if _mod_framework_ModManager then
+    _finish_mod_framework_init()
+  end
+
+  if self._in_update then
+    Log.info("Main", "Detected crash during update. Executing on_recover.")
+    self._sm:on_recover()
+  end
+
+  self._in_update = true
   self._sm:update(dt)
+  self._in_update = false
 end
 
 Main.render = function (self)
@@ -415,23 +390,11 @@ Main.on_close = function (self)
 end
 
 Main.shutdown = function (self)
-  local owns_package_manager = true
-
-  if rawget(_G, "Managers") and Managers.package then
-    Managers.package:shutdown_has_started()
-
-    owns_package_manager = false
-  end
-
   local exit_param = {
     on_shutdown = true,
   }
 
   self._sm:destroy(exit_param)
-
-  if owns_package_manager then
-    self._package_manager:delete()
-  end
 end
 
 function init()
@@ -536,7 +499,10 @@ function on_resume()
   end
 
   if IS_XBS then
-    XboxLiveUtils.close_user_context()
+    local ok, xlu = pcall(require, "scripts/foundation/utilities/xbox_live_utils")
+    if ok and xlu then
+      xlu.close_user_context()
+    end
   end
 end
 

--- a/binaries/mod_loader
+++ b/binaries/mod_loader
@@ -21,207 +21,207 @@ local io    = rawget(_G, "io")
 local ffi   = require("ffi")
 
 Mods = {
-  file = {},
-  message = {},
-  lua = {
-    debug = debug,
-    io = io,
-    ffi = ffi,
-    loadstring = loadstring,
-    os = os
-  }
+	file = {},
+	message = {},
+	lua = {
+		debug = debug,
+		io = io,
+		ffi = ffi,
+		loadstring = loadstring,
+		os = os
+	}
 }
 
 local chat_sound = "wwise/events/ui/play_ui_click"
 
 local notify = function(message)
-  local event_manager = Managers and Managers.event
+	local event_manager = Managers and Managers.event
 
-  if event_manager then
-    event_manager:trigger("event_add_notification_message", "default", message, nil, chat_sound)
-  end
+	if event_manager then
+		event_manager:trigger("event_add_notification_message", "default", message, nil, chat_sound)
+	end
 
-  print(message)
+	print(message)
 end
 Mods.message.notify = notify
 
 local echo = function(message, sender)
-  local chat_manager = Managers and Managers.chat
-  local event_manager = Managers and Managers.event
+	local chat_manager = Managers and Managers.chat
+	local event_manager = Managers and Managers.event
 
-  if chat_manager and event_manager then
-    local message_obj = {
-      message_body = message,
-      is_current_user = false,
-    }
+	if chat_manager and event_manager then
+		local message_obj = {
+			message_body = message,
+			is_current_user = false,
+		}
 
-    local participant = {
-      displayname = sender or "SYSTEM",
-    }
+		local participant = {
+			displayname = sender or "SYSTEM",
+		}
 
-    local message_sent = false
+		local message_sent = false
 
-    local channel_handle, channel = next(chat_manager:connected_chat_channels())
-    if channel then
-      event_manager:trigger("chat_manager_message_recieved", channel_handle, participant, message_obj)
-      message_sent = true
-    end
+		local channel_handle, channel = next(chat_manager:connected_chat_channels())
+		if channel then
+			event_manager:trigger("chat_manager_message_recieved", channel_handle, participant, message_obj)
+			message_sent = true
+		end
 
-    if not message_sent then
-      notify(message)
-      return
-    end
-  end
+		if not message_sent then
+			notify(message)
+			return
+		end
+	end
 
-  print(message)
+	print(message)
 end
 Mods.message.echo = echo
 
 local get_file_path = function(local_path, file_name, file_extension)
-  local file_path = mod_directory
+	local file_path = mod_directory
 
-  if local_path and local_path ~= "" then
-    file_path = file_path .. "/" .. local_path
-  end
+	if local_path and local_path ~= "" then
+		file_path = file_path .. "/" .. local_path
+	end
 
-  if file_name and file_name ~= "" then
-    file_path = file_path .. "/" .. file_name
-  end
+	if file_name and file_name ~= "" then
+		file_path = file_path .. "/" .. file_name
+	end
 
-  if file_extension and file_extension ~= "" then
-    file_path = file_path .. "." .. file_extension
-  else
-    file_path = file_path .. ".lua"
-  end
+	if file_extension and file_extension ~= "" then
+		file_path = file_path .. "." .. file_extension
+	else
+		file_path = file_path .. ".lua"
+	end
 
-  if string.find(file_path, "\\") then
-    file_path = string.gsub(file_path, "\\", "/")
-  end
+	if string.find(file_path, "\\") then
+		file_path = string.gsub(file_path, "\\", "/")
+	end
 
-  return file_path
+	return file_path
 end
 
 local function read_or_execute(file_path, args, return_type)
-  local f = io.open(file_path, "r")
+	local f = io.open(file_path, "r")
 
-  local result
-  if return_type == "lines" then
-    result = {}
-    for line in f:lines() do
-      if line then
-        -- Trim whitespace
-        line = line:gsub("^%s*(.-)%s*$", "%1")
+	local result
+	if return_type == "lines" then
+		result = {}
+		for line in f:lines() do
+			if line then
+				-- Trim whitespace
+				line = line:gsub("^%s*(.-)%s*$", "%1")
 
-        -- Handle empty lines and single-line comments
-        if line ~= "" and line:sub(1, 2) ~= "--" then
-          table.insert(result, line)
-        end
-      end
-    end
-  else
-    result = f:read("*all")
+				-- Handle empty lines and single-line comments
+				if line ~= "" and line:sub(1, 2) ~= "--" then
+					table.insert(result, line)
+				end
+			end
+		end
+	else
+		result = f:read("*all")
 
-    -- Either execute the data or leave it unmodified
-    if return_type == "exec_result" or return_type == "exec_boolean" then
-      local func = loadstring(result, file_path)
-      result = func(args)
-    end
-  end
+		-- Either execute the data or leave it unmodified
+		if return_type == "exec_result" or return_type == "exec_boolean" then
+			local func = loadstring(result, file_path)
+			result = func(args)
+		end
+	end
 
-  f:close()
-  if return_type == "exec_boolean" then
-    return true
-  else
-    return result
-  end
+	f:close()
+	if return_type == "exec_boolean" then
+		return true
+	else
+		return result
+	end
 end
 
 local function handle_io(local_path, file_name, file_extension, args, safe_call, return_type)
 
-  local file_path = get_file_path(local_path, file_name, file_extension)
-  print("[Mod] Loading " .. file_path)
+	local file_path = get_file_path(local_path, file_name, file_extension)
+	print("[Mod] Loading " .. file_path)
 
-  -- Check for the existence of the path
-  local ff, err_io = io.open(file_path, "r")
-  if ff ~= nil then
-    ff:close()
+	-- Check for the existence of the path
+	local ff, err_io = io.open(file_path, "r")
+	if ff ~= nil then
+		ff:close()
 
-    -- Initialize variables
-    local status, result
+		-- Initialize variables
+		local status, result
 
-    -- If this is a safe call, wrap it in a pcall
-    if safe_call then
-      status, result = pcall(function ()
-        return read_or_execute(file_path, args, return_type)
-      end)
+		-- If this is a safe call, wrap it in a pcall
+		if safe_call then
+			status, result = pcall(function ()
+				return read_or_execute(file_path, args, return_type)
+			end)
 
-      -- If status is failed, notify the user and return false
-      if not status then
-        notify("[Mod] Error processing '" .. file_path .. "': " .. tostring(result))
-        return false
-      end
+			-- If status is failed, notify the user and return false
+			if not status then
+				notify("[Mod] Error processing '" .. file_path .. "': " .. tostring(result))
+				return false
+			end
 
-    -- If this isn't a safe call, load without a pcall
-    else
-      result = read_or_execute(file_path, args, return_type)
-    end
+		-- If this isn't a safe call, load without a pcall
+		else
+			result = read_or_execute(file_path, args, return_type)
+		end
 
-    return result
+		return result
 
-  -- If the initial open failed, report failure
-  else
-    notify("[Mod] Error opening '" .. file_path .. "': " .. tostring(err_io))
-    return false
-  end
+	-- If the initial open failed, report failure
+	else
+		notify("[Mod] Error opening '" .. file_path .. "': " .. tostring(err_io))
+		return false
+	end
 end
 
 local function exec(local_path, file_name, file_extension, args)
-  return handle_io(local_path, file_name, file_extension, args, true, "exec_boolean")
+	return handle_io(local_path, file_name, file_extension, args, true, "exec_boolean")
 end
 Mods.file.exec = exec
 
 local function exec_unsafe(local_path, file_name, file_extension, args)
-  return handle_io(local_path, file_name, file_extension, args, false, "exec_boolean")
+	return handle_io(local_path, file_name, file_extension, args, false, "exec_boolean")
 end
 Mods.file.exec_unsafe = exec_unsafe
 
 local function exec_with_return(local_path, file_name, file_extension, args)
-  return handle_io(local_path, file_name, file_extension, args, true, "exec_result")
+	return handle_io(local_path, file_name, file_extension, args, true, "exec_result")
 end
 Mods.file.exec_with_return = exec_with_return
 
 local function exec_unsafe_with_return(local_path, file_name, file_extension, args)
-  return handle_io(local_path, file_name, file_extension, args, false, "exec_result")
+	return handle_io(local_path, file_name, file_extension, args, false, "exec_result")
 end
 Mods.file.exec_unsafe_with_return = exec_unsafe_with_return
 
 local function mod_dofile(file_path, args)
-  return handle_io(file_path, nil, nil, args, true, "exec_result")
+	return handle_io(file_path, nil, nil, args, true, "exec_result")
 end
 Mods.file.dofile = mod_dofile
 
 local function read_content(file_path, file_extension)
-  return handle_io(file_path, nil, file_extension, nil, true, "data")
+	return handle_io(file_path, nil, file_extension, nil, true, "data")
 end
 Mods.file.read_content = read_content
 
 local function read_content_to_table(file_path, file_extension)
-  return handle_io(file_path, nil, file_extension, nil, true, "lines")
+	return handle_io(file_path, nil, file_extension, nil, true, "lines")
 end
 Mods.file.read_content_to_table = read_content_to_table
 
 local file_exists = function(name)
-  print(name)
-  local f = io.open(name,"r")
+	print(name)
+	local f = io.open(name,"r")
 
-  if f ~= nil then
-    print("[Mod]: File exists")
-    io.close(f)
-    return true
-  else
-    print("[Mod]: File does not exist")
-    return false
-  end
+	if f ~= nil then
+		print("[Mod]: File exists")
+		io.close(f)
+		return true
+	else
+		print("[Mod]: File does not exist")
+		return false
+	end
 end
 Mods.file.exists = file_exists
 
@@ -235,77 +235,73 @@ _mod_framework_initialized = false
 
 local init_mod_framework = function()
 
-  print("[DMF]: Initializing basic mod hook system...")
-  exec("base/function", "hook")
+	print("[DMF]: Initializing basic mod hook system...")
+	exec("base/function", "hook")
 
-  -- The mod manager isn't in the bundles, so load our version from the mods folder
-  _mod_framework_ModManager = exec_with_return("base", "mod_manager")
+	-- The mod manager isn't in the bundles, so load our version from the mods folder
+	_mod_framework_ModManager = exec_with_return("base", "mod_manager")
 
-  -- Mark the session as modded before the new Crashify boot step reads GameParameters.
-  -- Wrapped in pcall since BootStateInitCrashify may not be registered yet.
-  pcall(Mods.hook.set, "Base", "_G.CLASS.BootStateInitCrashify._state_update", function (state_update_func, self, ...)
-    if GameParameters then
-      rawset(GameParameters, "is_modded_crashify_property", true)
-    end
+	-- Mark the session as modded before the new Crashify boot step reads GameParameters.
+	-- Wrapped in pcall since BootStateInitCrashify may not be registered yet.
+	pcall(Mods.hook.set, "Base", "_G.CLASS.BootStateInitCrashify._state_update", function (state_update_func, self, ...)
+		if GameParameters then
+			rawset(GameParameters, "is_modded_crashify_property", true)
+		end
 
-    return state_update_func(self, ...)
-  end)
+		return state_update_func(self, ...)
+	end)
 
-  print("[DMF]: Mod framework loaded, deferred initialization pending...")
+	print("[DMF]: Mod framework loaded, deferred initialization pending...")
 end
 
 -- Called from Main.update() once boot states have run and classes exist
 local _finish_mod_framework_init = function()
-  if _mod_framework_initialized then return end
-  if type(rawget(_G, "Managers")) ~= "table" then return end
-  -- Use rawget to bypass _G.CLASS.__index trap (returns string key if class not registered)
-  local state_game = _G.CLASS and rawget(_G.CLASS, "StateGame")
-  if type(state_game) ~= "table" then return end
+	if _mod_framework_initialized then return end
+	if type(rawget(_G, "Managers")) ~= "table" then return end
+	-- Use rawget to bypass _G.CLASS.__index trap (returns string key if class not registered)
+	local state_game = _G.CLASS and rawget(_G.CLASS, "StateGame")
+	if type(state_game) ~= "table" then return end
 
-  Managers.mod = Managers.mod or _mod_framework_ModManager:new()
+	Managers.mod = Managers.mod or _mod_framework_ModManager:new()
 
-  local all_ok = true
+	pcall(Mods.hook.set, "Base", "_G.CLASS.StateGame.update", function (func, self, dt, ...)
+		Managers.mod:update(dt)
+		return func(self, dt, ...)
+	end)
 
-  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.StateGame.update", function (func, self, dt, ...)
-    Managers.mod:update(dt)
-    return func(self, dt, ...)
-  end)
+	pcall(Mods.hook.set, "Base", "_G.CLASS.StateSplash.on_enter", function (func, self, ...)
+		local result = func(self, ...)
+		self._should_skip = true
+		self._continue = true
+		return result
+	end)
 
-  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.StateSplash.on_enter", function (func, self, ...)
-    local result = func(self, ...)
-    self._should_skip = true
-    self._continue = true
-    return result
-  end)
+	pcall(Mods.hook.set, "Base", "_G.CLASS.GameStateMachine._change_state", function (func, self, ...)
+		local old_state = self._state
+		local old_state_name = old_state and self:current_state_name()
+		if old_state_name then
+			Managers.mod:on_game_state_changed("exit", old_state_name, old_state)
+		end
+		local result = func(self, ...)
+		local new_state = self._state
+		local new_state_name = new_state and self:current_state_name()
+		if new_state_name then
+			Managers.mod:on_game_state_changed("enter", new_state_name, new_state)
+		end
+		return result
+	end)
 
-  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.GameStateMachine._change_state", function (func, self, ...)
-    local old_state = self._state
-    local old_state_name = old_state and self:current_state_name()
-    if old_state_name then
-      Managers.mod:on_game_state_changed("exit", old_state_name, old_state)
-    end
-    local result = func(self, ...)
-    local new_state = self._state
-    local new_state_name = new_state and self:current_state_name()
-    if new_state_name then
-      Managers.mod:on_game_state_changed("enter", new_state_name, new_state)
-    end
-    return result
-  end)
+	pcall(Mods.hook.set, "Base", "_G.CLASS.GameStateMachine.destroy", function (func, self, ...)
+		local old_state = self._state
+		local old_state_name = old_state and self:current_state_name()
+		if old_state_name then
+			Managers.mod:on_game_state_changed("exit", old_state_name)
+		end
+		return func(self, ...)
+	end)
 
-  all_ok = all_ok and pcall(Mods.hook.set, "Base", "_G.CLASS.GameStateMachine.destroy", function (func, self, ...)
-    local old_state = self._state
-    local old_state_name = old_state and self:current_state_name()
-    if old_state_name then
-      Managers.mod:on_game_state_changed("exit", old_state_name)
-    end
-    return func(self, ...)
-  end)
-
-  if all_ok then
-    _mod_framework_initialized = true
-    print("[DMF]: Mod framework fully initialized for v1.3.11!")
-  end
+	_mod_framework_initialized = true
+	print("[DMF]: Mod framework fully initialized for v1.3.11!")
 end
 
 -- Original main script
@@ -327,158 +323,155 @@ require("scripts/foundation/utilities/settings")
 require("scripts/foundation/utilities/table")
 
 GAME_RESUME_COUNT = GAME_RESUME_COUNT or 0
-FRAME_INDEX = FRAME_INDEX or -1
 
 Main.init = function (self)
-  Script.configure_garbage_collection(Script.ACCEPTABLE_GARBAGE, 0.1, Script.MAXIMUM_GARBAGE, 0.5, Script.FORCE_FULL_COLLECT_GARBAGE_LEVEL, 1, Script.MINIMUM_COLLECT_TIME_MS, 0.5, Script.MAXIMUM_COLLECT_TIME_MS, 1)
+	Script.configure_garbage_collection(Script.ACCEPTABLE_GARBAGE, 0.1, Script.MAXIMUM_GARBAGE, 0.5, Script.FORCE_FULL_COLLECT_GARBAGE_LEVEL, 1, Script.MINIMUM_COLLECT_TIME_MS, 0.5, Script.MAXIMUM_COLLECT_TIME_MS, 1)
 
-  local GameStateDebug = require("scripts/utilities/game_state_debug")
-  local GameStateMachine = require("scripts/foundation/utilities/game_state_machine")
-  local StateBoot = require("scripts/game_states/state_boot")
+	local GameStateDebug = require("scripts/utilities/game_state_debug")
+	local GameStateMachine = require("scripts/foundation/utilities/game_state_machine")
+	local StateBoot = require("scripts/game_states/state_boot")
 
-  local start_params = {
-    next_state_class_name = "StateGame",
-    boot_state_paths = {
-      "scripts/game_states/boot/boot_state_set_globals",
-      "scripts/game_states/boot/boot_state_apply_patches",
-      "scripts/game_states/boot/boot_state_resolve_parameters",
-      "scripts/game_states/boot/boot_state_create_boot_ui",
-      "scripts/game_states/boot/boot_state_load_render_settings",
-      "scripts/game_states/boot/boot_state_init_managers",
-      "scripts/game_states/boot/boot_state_load_boot_assets",
-      "scripts/game_states/boot/boot_state_require_foundation_scripts",
-      "scripts/game_states/boot/boot_state_init_crashify",
-      "scripts/game_states/boot/boot_state_init_testify",
-      "scripts/game_states/boot/boot_state_require_game_scripts",
-      "scripts/game_states/boot/boot_state_load_audio_settings",
-      "scripts/game_states/boot/boot_state_activate_plugins",
-      "scripts/game_states/boot/boot_state_startup_tests",
-      "scripts/game_states/boot/boot_state_last",
-    },
-  }
+	local start_params = {
+		next_state_class_name = "StateGame",
+		boot_state_paths = {
+			"scripts/game_states/boot/boot_state_set_globals",
+			"scripts/game_states/boot/boot_state_apply_patches",
+			"scripts/game_states/boot/boot_state_resolve_parameters",
+			"scripts/game_states/boot/boot_state_create_boot_ui",
+			"scripts/game_states/boot/boot_state_load_render_settings",
+			"scripts/game_states/boot/boot_state_init_managers",
+			"scripts/game_states/boot/boot_state_load_boot_assets",
+			"scripts/game_states/boot/boot_state_require_foundation_scripts",
+			"scripts/game_states/boot/boot_state_init_crashify",
+			"scripts/game_states/boot/boot_state_init_testify",
+			"scripts/game_states/boot/boot_state_require_game_scripts",
+			"scripts/game_states/boot/boot_state_load_audio_settings",
+			"scripts/game_states/boot/boot_state_activate_plugins",
+			"scripts/game_states/boot/boot_state_startup_tests",
+			"scripts/game_states/boot/boot_state_last",
+		},
+	}
 
-  rawset(_G, "GameStateDebugInfo", GameStateDebug:new())
+	rawset(_G, "GameStateDebugInfo", GameStateDebug:new())
 
-  self._sm = GameStateMachine:new(nil, StateBoot, start_params, nil, nil, "", "Main", true)
+	self._sm = GameStateMachine:new(nil, StateBoot, start_params, nil, nil, "", "Main", true)
 
-  -- #######################
-  -- ## Mod intialization ##
-  init_mod_framework()
-  -- #######################
+	-- #######################
+	-- ## Mod intialization ##
+	init_mod_framework()
+	-- #######################
 end
 
 Main.update = function (self, dt)
-  FRAME_INDEX = FRAME_INDEX + 1
+	-- DML v1.3.11: finish mod framework init once classes are available
+	if _mod_framework_ModManager then
+		_finish_mod_framework_init()
+	end
 
-  -- DML v1.3.11: finish mod framework init once classes are available
-  if _mod_framework_ModManager then
-    _finish_mod_framework_init()
-  end
+	if self._in_update then
+		Log.info("Main", "Detected crash during update. Executing on_recover.")
+		self._sm:on_recover()
+	end
 
-  if self._in_update then
-    Log.info("Main", "Detected crash during update. Executing on_recover.")
-    self._sm:on_recover()
-  end
-
-  self._in_update = true
-  self._sm:update(dt)
-  self._in_update = false
+	self._in_update = true
+	self._sm:update(dt)
+	self._in_update = false
 end
 
 Main.render = function (self)
-  self._sm:render()
+	self._sm:render()
 end
 
 Main.on_reload = function (self, refreshed_resources)
-  self._sm:on_reload(refreshed_resources)
+	self._sm:on_reload(refreshed_resources)
 end
 
 Main.on_activate = function (self, is_active)
-  Log.info("Main", "LUA window => " .. (is_active and "ACTIVATED" or "DEACTIVATED"))
-  self._sm:on_activate(is_active)
+	Log.info("Main", "LUA window => " .. (is_active and "ACTIVATED" or "DEACTIVATED"))
+	self._sm:on_activate(is_active)
 end
 
 Main.on_close = function (self)
-  local should_close = self._sm:on_close()
+	local should_close = self._sm:on_close()
 
-  if should_close then
-    Application.force_silent_exit_policy()
-  end
+	if should_close then
+		Application.force_silent_exit_policy()
+	end
 
-  return should_close
+	return should_close
 end
 
 Main.on_suspend = function (self)
-  self._sm:on_suspend()
+	self._sm:on_suspend()
 end
 
 Main.on_resume = function (self)
-  GAME_RESUME_COUNT = GAME_RESUME_COUNT + 1
+	GAME_RESUME_COUNT = GAME_RESUME_COUNT + 1
 
-  local Crashify = rawget(_G, "Crashify")
+	local Crashify = rawget(_G, "Crashify")
 
-  if Crashify then
-    Crashify.print_property("game_resume_count", GAME_RESUME_COUNT)
-    Crashify.print_breadcrumb(string.format("on_resume: %s", GAME_RESUME_COUNT))
-  end
+	if Crashify then
+		Crashify.print_property("game_resume_count", GAME_RESUME_COUNT)
+		Crashify.print_breadcrumb(string.format("on_resume: %s", GAME_RESUME_COUNT))
+	end
 
-  self._sm:on_resume()
+	self._sm:on_resume()
 end
 
 Main.on_constrained = function (self, is_constrained)
-  return self._sm:on_constrained(is_constrained)
+	return self._sm:on_constrained(is_constrained)
 end
 
 Main.shutdown = function (self)
-  local exit_param = {
-    on_shutdown = true,
-  }
+	local exit_param = {
+		on_shutdown = true,
+	}
 
-  self._sm:destroy(exit_param)
+	self._sm:destroy(exit_param)
 end
 
 local Main = Main
 
 function init()
-  return Main:init()
+	return Main:init()
 end
 
 function update(dt)
-  return Main:update(dt)
+	return Main:update(dt)
 end
 
 function render()
-  return Main:render()
+	return Main:render()
 end
 
 function shutdown()
-  return Main:shutdown()
+	return Main:shutdown()
 end
 
 function on_reload(refreshed_resources)
-  return Main:on_reload(refreshed_resources)
+	return Main:on_reload(refreshed_resources)
 end
 
 function on_activate(is_active)
-  return Main:on_activate(is_active)
+	return Main:on_activate(is_active)
 end
 
 function on_close()
-  return Main:on_close()
+	return Main:on_close()
 end
 
 function on_suspend()
-  return Main:on_suspend()
+	return Main:on_suspend()
 end
 
 function on_resume()
-  return Main:on_resume()
+	return Main:on_resume()
 end
 
 function on_constrained(is_constrained)
-  return Main:on_constrained(is_constrained)
+	return Main:on_constrained(is_constrained)
 end
 
 function on_low_memory_state_dump(global_path, registry_path, total_allocated, total_used)
-  Log.exception("Memory", "Low on Lua memory. Allocated: '%d', Used: '%d'\n\t\t_G dump: %s\n\t\tRegistry dump: %s\n\t", global_path, registry_path, total_allocated, total_used)
+	Log.exception("Memory", "Low on Lua memory. Allocated: '%d', Used: '%d'\n\t\t_G dump: %s\n\t\tRegistry dump: %s\n\t", total_allocated, total_used, global_path, registry_path)
 end

--- a/binaries/mod_loader
+++ b/binaries/mod_loader
@@ -241,6 +241,16 @@ local init_mod_framework = function()
   -- The mod manager isn't in the bundles, so load our version from the mods folder
   _mod_framework_ModManager = exec_with_return("base", "mod_manager")
 
+  -- Mark the session as modded before the new Crashify boot step reads GameParameters.
+  -- Wrapped in pcall since BootStateInitCrashify may not be registered yet.
+  pcall(Mods.hook.set, "Base", "_G.CLASS.BootStateInitCrashify._state_update", function (state_update_func, self, ...)
+    if GameParameters then
+      rawset(GameParameters, "is_modded_crashify_property", true)
+    end
+
+    return state_update_func(self, ...)
+  end)
+
   print("[DMF]: Mod framework loaded, deferred initialization pending...")
 end
 
@@ -383,10 +393,40 @@ Main.on_reload = function (self, refreshed_resources)
   self._sm:on_reload(refreshed_resources)
 end
 
+Main.on_activate = function (self, is_active)
+  Log.info("Main", "LUA window => " .. (is_active and "ACTIVATED" or "DEACTIVATED"))
+  self._sm:on_activate(is_active)
+end
+
 Main.on_close = function (self)
   local should_close = self._sm:on_close()
 
+  if should_close then
+    Application.force_silent_exit_policy()
+  end
+
   return should_close
+end
+
+Main.on_suspend = function (self)
+  self._sm:on_suspend()
+end
+
+Main.on_resume = function (self)
+  GAME_RESUME_COUNT = GAME_RESUME_COUNT + 1
+
+  local Crashify = rawget(_G, "Crashify")
+
+  if Crashify then
+    Crashify.print_property("game_resume_count", GAME_RESUME_COUNT)
+    Crashify.print_breadcrumb(string.format("on_resume: %s", GAME_RESUME_COUNT))
+  end
+
+  self._sm:on_resume()
+end
+
+Main.on_constrained = function (self, is_constrained)
+  return self._sm:on_constrained(is_constrained)
 end
 
 Main.shutdown = function (self)
@@ -397,119 +437,48 @@ Main.shutdown = function (self)
   self._sm:destroy(exit_param)
 end
 
+local Main = Main
+
 function init()
-  Main:init()
+  return Main:init()
 end
 
 function update(dt)
-  Main:update(dt)
+  return Main:update(dt)
 end
 
 function render()
-  Main:render()
-end
-
-function on_reload(refreshed_resources)
-  Main:on_reload(refreshed_resources)
-end
-
-function on_activate(active)
-  Log.info("Main", "LUA window => " .. (active and "ACTIVATED" or "DEACTIVATED"))
-
-  if active and rawget(_G, "Managers") then
-    if Managers.dlc then
-      Managers.dlc:evaluate_consumables()
-    end
-
-    if Managers.account then
-      Managers.account:refresh_communication_restrictions()
-    end
-  end
-end
-
-function on_close()
-  local should_close = Main:on_close()
-
-  if should_close then
-    Application.force_silent_exit_policy()
-
-    if rawget(_G, "Crashify") then
-      Crashify.print_property("shutdown", true)
-    end
-  end
-
-  return should_close
-end
-
-function on_constrained(is_constrained)
-  if rawget(_G, "Managers") and Managers.event then
-    Managers.event:trigger("on_constrained", is_constrained)
-  end
-end
-
-function on_suspend()
-  if rawget(_G, "Managers") then
-    Managers.event:trigger("on_pre_suspend")
-    Managers.event:trigger("on_suspend")
-
-    local update_grpc = false
-
-    if Managers.party_immaterium then
-      Managers.party_immaterium:reset()
-
-      update_grpc = true
-    end
-
-    if Managers.presence then
-      Managers.presence:reset()
-
-      update_grpc = true
-    end
-
-    if update_grpc and Managers.grpc then
-      Managers.grpc:update(0)
-    end
-
-    if Managers.telemetry_events then
-      Managers.telemetry_events:game_suspended()
-    end
-  end
-end
-
-function on_resume()
-  GAME_RESUME_COUNT = GAME_RESUME_COUNT + 1
-
-  if rawget(_G, "Crashify") then
-    Crashify.print_property("game_resume_count", GAME_RESUME_COUNT)
-    Crashify.print_breadcrumb(string.format("on_resume: %s", GAME_RESUME_COUNT))
-  end
-
-  if rawget(_G, "Managers") then
-    if Managers.backend then
-      Managers.backend:time_sync_restart()
-    end
-
-    if Managers.telemetry_events then
-      Managers.telemetry_events:game_resumed()
-    end
-
-    if Managers.telemetry then
-      Managers.telemetry:post_batch()
-    end
-  end
-
-  if IS_XBS then
-    local ok, xlu = pcall(require, "scripts/foundation/utilities/xbox_live_utils")
-    if ok and xlu then
-      xlu.close_user_context()
-    end
-  end
+  return Main:render()
 end
 
 function shutdown()
-  Main:shutdown()
+  return Main:shutdown()
+end
+
+function on_reload(refreshed_resources)
+  return Main:on_reload(refreshed_resources)
+end
+
+function on_activate(is_active)
+  return Main:on_activate(is_active)
+end
+
+function on_close()
+  return Main:on_close()
+end
+
+function on_suspend()
+  return Main:on_suspend()
+end
+
+function on_resume()
+  return Main:on_resume()
+end
+
+function on_constrained(is_constrained)
+  return Main:on_constrained(is_constrained)
 end
 
 function on_low_memory_state_dump(global_path, registry_path, total_allocated, total_used)
-  Log.exception("Memory", "Low on Lua memory. Allocated: '%d', Used: '%d'\n\t\t_G dump: %s\n\t\tRegistry dump: %s\n\t", total_allocated, total_used, global_path, registry_path)
+  Log.exception("Memory", "Low on Lua memory. Allocated: '%d', Used: '%d'\n\t\t_G dump: %s\n\t\tRegistry dump: %s\n\t", global_path, registry_path, total_allocated, total_used)
 end


### PR DESCRIPTION
## Problem

The current mod_loader was written for Darktide v1.10.0 and earlier. Fatshark restructured the boot sequence in v1.3.11, which breaks the mod loader entirely — the game crashes on startup with:

```
module "scripts/foundation/utilities/patches" not found
```

After patching that, it cascades to:

```
module "scripts/game_states/boot/state_load_audio_settings" not found
```

The root cause is that Fatshark replaced the old hardcoded boot state list with a string-based `boot_state_paths` architecture, and `StateRequireScripts` no longer exists as a class.

## What Changed

### Boot sequence (Main.init)
- Replaced the old `states` array with `boot_state_paths` — a table of 15 boot state script paths that GameStateMachine loads as strings
- GameStateMachine:new() now takes `start_params` with `next_state_class_name` + `boot_state_paths` instead of a `states` array

### Mod framework initialization (init_mod_framework / _finish_mod_framework_init)
- The old approach hooked `_G.CLASS.StateRequireScripts._require_scripts` to trigger mod loading. Since StateRequireScripts is gone, this can not work
- Moved all `Mods.hook.set` calls into a new `_finish_mod_framework_init()` function that runs from `Main.update()` once `StateGame` class actually exists
- Used `rawget(_G.CLASS, "StateGame")` to check class registration — `_G.CLASS.__index` returns the string key (truthy) when a class is not registered, so `_G.CLASS.StateGame` always looks valid even before StateGame is loaded
- Each `Mods.hook.set` wrapped in `pcall` so StateSplash hook retries gracefully (StateSplash registers after StateGame)

### Crashify integration
- Hook `BootStateInitCrashify._state_update` to set `is_modded_crashify_property` on GameParameters before crash reporting reads it
- Wrapped in pcall since BootStateInitCrashify may not be registered yet at hook time

### Crash recovery
- Added `FRAME_INDEX` tracking and `_in_update` guard in `Main.update()` with `on_recover()` fallback

### Main methods
- Added proper `Main.on_activate`, `Main.on_suspend`, `Main.on_resume`, `Main.on_constrained` methods
- `Main.on_resume` includes Crashify breadcrumb printing for crash reporting
- `Main.on_close` includes `Application.force_silent_exit_policy()`

### Simplified global functions
- All global functions (`init`, `update`, `render`, `shutdown`, `on_reload`, `on_activate`, `on_close`, `on_suspend`, `on_resume`, `on_constrained`) are now thin trampolines delegating to Main methods
- All return values are properly forwarded

## Testing

Tested on Darktide v1.12.0 with 124 mods loaded via AML + DMF. Full game sessions with no script errors, clean exit.

## Notes

This maintains the same mod_loader interface — DMF and AML work without changes. The only difference is how the boot sequence is structured internally.

If Fatshark changes the boot_state_paths list in a future update, the table in Main.init will need updating. The paths are:

```
boot_state_set_globals, boot_state_apply_patches, boot_state_resolve_parameters,
boot_state_create_boot_ui, boot_state_load_render_settings, boot_state_init_managers,
boot_state_load_boot_assets, boot_state_require_foundation_scripts, boot_state_init_crashify,
boot_state_init_testify, boot_state_require_game_scripts, boot_state_load_audio_settings,
boot_state_activate_plugins, boot_state_startup_tests, boot_state_last
```
